### PR TITLE
Installs Python for node-gyp

### DIFF
--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,6 +1,11 @@
 FROM node:lts-alpine
 WORKDIR /app
 COPY frontend/app/package*.json ./
+RUN apk --no-cache add --virtual native-deps \
+  g++ gcc libgcc libstdc++ linux-headers make python && \
+  npm install --quiet node-gyp -g && \
+  npm install --quiet && \
+  apk del native-deps
 RUN npm install
 COPY frontend/app/ ./
 CMD ["npm", "run", "serve"]

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -2,6 +2,11 @@
 FROM node:lts-alpine as builder
 WORKDIR /app
 COPY frontend/app/package*.json ./
+RUN apk --no-cache add --virtual native-deps \
+  g++ gcc libgcc libstdc++ linux-headers make python && \
+  npm install --quiet node-gyp -g && \
+  npm install --quiet && \
+  apk del native-deps
 RUN npm install
 COPY frontend/app/ ./
 RUN npm run build


### PR DESCRIPTION
This installs Python inside the frontend container, which is required by node-gyp in order to compile some Node packages when there isn't a binary release available.